### PR TITLE
Bug fixed ( when you press the back without save the modified file, then ... I fixed that )

### DIFF
--- a/src/FileExplorerApp.cpp
+++ b/src/FileExplorerApp.cpp
@@ -1323,11 +1323,11 @@ void FileExplorerApp::RenderFileViewer(float menu_bar_height)
             {
                 // Render the text editor with syntax highlighting
                 // Get available space
-                ImVec2 availableSize = ImGui::GetContentRegionAvail();
+                ImVec2 available_size = ImGui::GetContentRegionAvail();
                 
                 // Render the TextEditor
-                m_TextEditor.Render("##TextEditor", availableSize);
-                
+                m_TextEditor.Render("##TextEditor", available_size);
+            
                 // Check if text was modified
                 if (m_TextEditor.IsTextChanged())
                 {

--- a/src/FileExplorerApp.cpp
+++ b/src/FileExplorerApp.cpp
@@ -1142,10 +1142,16 @@ void FileExplorerApp::HandleSaveBeforeDirChangePopup()
                     out_file.write(content.data(), content.size());
                     out_file.close();
                     m_bFileModified = false;
+                    NavigateToDirectory(m_PendingDirectoryToNavigate);
+                    m_PendingDirectoryToNavigate = fs::path();
+                }
+                else
+                {
+                    m_ErrorMessage = "Could not save file: " + m_SelectedFile.string();
+                    m_bShowErrorPopup = true;
+                    m_PendingDirectoryToNavigate = fs::path();
                 }
             }
-            NavigateToDirectory(m_PendingDirectoryToNavigate);
-            m_PendingDirectoryToNavigate = fs::path();
             ImGui::CloseCurrentPopup();
         }
         

--- a/src/FileExplorerApp.h
+++ b/src/FileExplorerApp.h
@@ -74,6 +74,8 @@ private:
     // Function to render the explorer side panel
     void RenderExplorerPanel(float menu_bar_height, bool& b_Open);
 
+    void HandleSaveBeforeDirChangePopup();
+
     // Function to update side menu width for resizing
     void UpdateSideMenuWidth();
 
@@ -90,6 +92,7 @@ private:
     void SetEditorLanguage(const fs::path& filePath);
     const TextEditor::LanguageDefinition& GetLanguageDefinition(const string& extension);
     void OpenFile(const fs::path& file_path);
+    void NavigateToDirectory(const fs::path& new_path);
 
 private:
     
@@ -102,6 +105,7 @@ private:
     bool m_bExit;
     bool m_bShowExitConfirm;
     bool m_bShowSaveBeforeOpenConfirm;
+    bool m_bShowSaveBeforeDirChangeConfirm;
 
     Texture2D m_FileIcon;
     Texture2D m_FolderIcon;
@@ -112,6 +116,7 @@ private:
     bool m_bImgLoaded;
     fs::path m_LoadedImgPath;
     fs::path m_PendingFileToOpen;
+    fs::path m_PendingDirectoryToNavigate;
 
     bool m_bShowSaveDialog;
     bool m_bShowErrorPopup;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when navigating to a different directory with unsaved changes (Save / Don't Save / Cancel).
  * Navigation now queues the target directory and proceeds after the chosen action.

* **Improvements**
  * Centralized navigation flow to ensure proper cleanup and state reset when changing directories.
  * Integrated the save-before-navigation check into the app run loop to reduce accidental data loss.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->